### PR TITLE
Prefer cmd.Dir over os.Chdir

### DIFF
--- a/oscd.go
+++ b/oscd.go
@@ -46,13 +46,9 @@ func main() {
 		log.Fatalf("error: %v\n", err)
 	}
 
-	// change to directory
-	if err := os.Chdir(targetDir); err != nil {
-		log.Fatalf("error: %v\n", err)
-	}
-
 	// build command
 	cmd := exec.Command(command, os.Args[3:]...)
+	cmd.Dir = targetDir
 	cmd.Env = os.Environ()
 
 	// execute command


### PR DESCRIPTION
i figure if you wanted have the behavior of moving between 2 dirs, then you would want to be able to inject some sort of function (switch dir, exec cmd, then after switching back run something) if it relied on that.

but if that is not necessary then i think it would be best to use `cmd.Dir` to state the where the command should be executed as using `os.Chdir` will provide a redundant check (unless you blank the error) as the process of finding the abspath will throw an error if the dir does not exist. 

front end is the enemy